### PR TITLE
REST sink support

### DIFF
--- a/docs/en_US/rules/overview.md
+++ b/docs/en_US/rules/overview.md
@@ -45,7 +45,7 @@ The sql query to run for the rule.
 
 ### actions
 
-Currently, 2 kinds of actions are supported: [log](sinks/logs.md) and [mqtt](sinks/mqtt.md). Each action can define its own properties.
+Currently, 3 kinds of actions are supported: [log](sinks/logs.md), [mqtt](sinks/mqtt.md) and [rest](sinks/rest.md). Each action can define its own properties.
 
 Actions could be customized to support different kinds of outputs, see [extension](../extension/overview.md) for more detailed info.
 

--- a/docs/en_US/rules/sinks/rest.md
+++ b/docs/en_US/rules/sinks/rest.md
@@ -1,0 +1,23 @@
+# REST action
+
+The action is used for publish output message into a RESTful API.
+
+| Property name     | Optional | Description                                                  |
+| ----------------- | -------- | ------------------------------------------------------------ |
+| method            | true    | The http method for the RESTful API. It is a case insensitive string whose value is among "get", "post", "put", "patch", "delete" and "head". The default value is "get. |
+| url             | false    | The RESTful API endpoint, such as ``https://www.example.com/api/dummy``                  |
+| bodyType          | true     | The type of the body. Currently, 3 types are supported: "none", "raw" and "form". For "get" and "head", no body is required so the default value is "none". For other http methods, the default value is "raw". |
+| timeout   | true     | The timeout (milliseconds) for a http request, defaults to 5000 ms |
+| headers            | true     | The additional headers to be set for the http request. |
+| sendSingle        | true     | The output messages are received as an array. This is indicate whether to send the results one by one. If false, the output message will be ``{"result":"${the string of received message}"}``. For example, ``{"result":"[{\"count\":30},"\"count\":20}]"}``. Otherwise, the result message will be sent one by one with the actual field name. For the same example as above, it will send ``{"count":30}``, then send ``{"count":20}`` to the RESTful endpoint.Default to false. |
+
+Below is sample configuration for connecting to Edgex Foundry core command.
+```json
+    {
+      "rest": {
+        "url": "http://127.0.0.1:48082/api/v1/device/cc622d99-f835-4e94-b5cb-b1eff8699dc4/command/51fce08a-ae19-4bce-b431-b9f363bba705",       
+        "method": "post",
+        "sendSingle": true
+      }
+    }
+```

--- a/docs/zh_CN/rules/overview.md
+++ b/docs/zh_CN/rules/overview.md
@@ -45,7 +45,7 @@
 
 ### 动作
 
-当前，支持两种操作： [log](sinks/logs.md) 和 [mqtt](sinks/mqtt.md).。 每个动作可以定义自己的属性。
+当前，支持两种操作： [log](sinks/logs.md) 、[mqtt](sinks/mqtt.md) 和 [rest](sinks/rest.md)。 每个动作可以定义自己的属性。
 
 可以自定义动作以支持不同种类的输出，有关更多详细信息，请参见 [extension](../extension/overview.md) 。
 

--- a/docs/zh_CN/rules/sinks/rest.md
+++ b/docs/zh_CN/rules/sinks/rest.md
@@ -1,0 +1,23 @@
+# REST action
+
+The action is used for publish output message into a RESTful API.
+
+| Property name     | Optional | Description                                                  |
+| ----------------- | -------- | ------------------------------------------------------------ |
+| method            | true    | The http method for the RESTful API. It is a case insensitive string whose value is among "get", "post", "put", "patch", "delete" and "head". The default value is "get. |
+| url             | false    | The RESTful API endpoint, such as ``https://www.example.com/api/dummy``                  |
+| bodyType          | true     | The type of the body. Currently, 3 types are supported: "none", "raw" and "form". For "get" and "head", no body is required so the default value is "none". For other http methods, the default value is "raw". |
+| timeout   | true     | The timeout (milliseconds) for a http request, defaults to 5000 ms |
+| headers            | true     | The additional headers to be set for the http request. |
+| sendSingle        | true     | The output messages are received as an array. This is indicate whether to send the results one by one. If false, the output message will be ``{"result":"${the string of received message}"}``. For example, ``{"result":"[{\"count\":30},"\"count\":20}]"}``. Otherwise, the result message will be sent one by one with the actual field name. For the same example as above, it will send ``{"count":30}``, then send ``{"count":20}`` to the RESTful endpoint.Default to false. |
+
+Below is sample configuration for connecting to Edgex Foundry core command.
+```json
+    {
+      "rest": {
+        "url": "http://127.0.0.1:48082/api/v1/device/cc622d99-f835-4e94-b5cb-b1eff8699dc4/command/51fce08a-ae19-4bce-b431-b9f363bba705",       
+        "method": "post",
+        "sendSingle": true
+      }
+    }
+```

--- a/xsql/plans/preprocessor.go
+++ b/xsql/plans/preprocessor.go
@@ -63,7 +63,7 @@ func (p *Preprocessor) Apply(ctx api.StreamContext, data interface{}) interface{
 		if f.AName != "" && (!xsql.HasAggFuncs(f.Expr)) {
 			ve := &xsql.ValuerEval{Valuer: xsql.MultiValuer(tuple, &xsql.FunctionValuer{})}
 			if v := ve.Eval(f.Expr); v != nil {
-				result[f.AName] = v
+				result[strings.ToLower(f.AName)] = v
 			}
 		}
 	}

--- a/xsql/processors/xsql_processor.go
+++ b/xsql/processors/xsql_processor.go
@@ -477,6 +477,8 @@ func getSink(name string, action map[string]interface{}) (api.Sink, error) {
 		s = sinks.NewLogSink()
 	case "mqtt":
 		s = &sinks.MQTTSink{}
+	case "rest":
+		s = &sinks.RestSink{}
 	default:
 		nf, err := plugin_manager.GetPlugin(name, "sinks")
 		if err != nil {

--- a/xsql/processors/xsql_processor_test.go
+++ b/xsql/processors/xsql_processor_test.go
@@ -404,6 +404,19 @@ func TestSingleSQL(t *testing.T) {
 					"ts":    float64(1541152488442),
 				}},
 			},
+		}, {
+			name: `rule3`,
+			sql:  `SELECT size as Int8, ts FROM demo where size > 3`,
+			r: [][]map[string]interface{}{
+				{{
+					"Int8":  float64(6),
+					"ts":    float64(1541152486822),
+				}},
+				{{
+					"Int8":  float64(4),
+					"ts":    float64(1541152488442),
+				}},
+			},
 		},
 	}
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))

--- a/xstream/nodes/sink_node.go
+++ b/xstream/nodes/sink_node.go
@@ -37,10 +37,12 @@ func (m *SinkNode) Open(ctx api.StreamContext, result chan<- error) {
 		for {
 			select {
 			case item := <-m.input:
-				if err := m.sink.Collect(ctx, item); err != nil{
-					//TODO deal with publish error
-					logger.Errorf("sink node %s publish %v error: %v", ctx.GetOpId(), item, err)
-				}
+				go func() {
+					if err := m.sink.Collect(ctx, item); err != nil{
+						//TODO deal with publish error
+						logger.Errorf("sink node %s publish %v error: %v", ctx.GetOpId(), item, err)
+					}
+				}()
 			case <-ctx.Done():
 				logger.Infof("sink node %s done", m.name)
 				if err := m.sink.Close(ctx); err != nil{

--- a/xstream/sinks/mqtt_sink.go
+++ b/xstream/sinks/mqtt_sink.go
@@ -2,10 +2,10 @@ package sinks
 
 import (
 	"crypto/tls"
-	"github.com/emqx/kuiper/common"
-	"github.com/emqx/kuiper/xstream/api"
 	"fmt"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
+	"github.com/emqx/kuiper/common"
+	"github.com/emqx/kuiper/xstream/api"
 	"github.com/google/uuid"
 	"strings"
 )
@@ -41,7 +41,7 @@ func (ms *MQTTSink) Configure(ps map[string]interface{}) error {
 		}
 	}
 	var pVersion uint = 3
-	pVersionStr, ok := ps["protocolVersion"];
+	pVersionStr, ok := ps["protocolVersion"]
 	if ok {
 		v, _ := pVersionStr.(string)
 		if v == "3.1" {
@@ -54,7 +54,7 @@ func (ms *MQTTSink) Configure(ps map[string]interface{}) error {
 	}
 
 	uName := ""
-	un, ok := ps["username"];
+	un, ok := ps["username"]
 	if ok {
 		v, _ := un.(string)
 		if strings.Trim(v, " ") != "" {
@@ -63,7 +63,7 @@ func (ms *MQTTSink) Configure(ps map[string]interface{}) error {
 	}
 
 	password := ""
-	pwd, ok := ps["password"];
+	pwd, ok := ps["password"]
 	if ok {
 		v, _ := pwd.(string)
 		if strings.Trim(v, " ") != "" {
@@ -155,5 +155,3 @@ func (ms *MQTTSink) Close(ctx api.StreamContext) error {
 	}
 	return nil
 }
-
-

--- a/xstream/sinks/rest_sink.go
+++ b/xstream/sinks/rest_sink.go
@@ -1,0 +1,202 @@
+package sinks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/emqx/kuiper/xstream/api"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type RestSink struct {
+	method      string
+	url         string
+	headers     map[string]string
+	bodyType    string
+	timeout		int64
+	sendSingle  bool
+
+	client      *http.Client
+}
+
+var methodsMap = map[string]bool{"GET": true, "HEAD": true, "POST": true, "PUT": true, "DELETE": true, "PATCH": true}
+var bodyTypeMap = map[string]bool{"none":true, "raw": true, "form": true}
+
+func (ms *RestSink) Configure(ps map[string]interface{}) error {
+	temp, ok := ps["method"]
+	if ok {
+		ms.method, ok = temp.(string)
+		if !ok {
+			return fmt.Errorf("rest sink property method %v is not a string", temp)
+		}
+		ms.method = strings.ToUpper(strings.Trim(ms.method, ""))
+	}else{
+		ms.method = "GET"
+	}
+	if _, ok = methodsMap[ms.method]; !ok {
+		return fmt.Errorf("invalid property method: %s", ms.method)
+	}
+	switch ms.method{
+	case "GET", "HEAD":
+		ms.bodyType = "none"
+	default:
+		ms.bodyType = "raw"
+	}
+
+	temp, ok = ps["url"]
+	if !ok {
+		return fmt.Errorf("rest sink is missing property url")
+	}
+	ms.url, ok = temp.(string)
+	if !ok {
+		return fmt.Errorf("rest sink property url %v is not a string", temp)
+	}
+	ms.url = strings.ToLower(strings.Trim(ms.url, ""))
+
+	temp, ok = ps["headers"]
+	if ok{
+		ms.headers, ok = temp.(map[string]string)
+		if !ok {
+			return fmt.Errorf("rest sink property headers %v is not a map[string][]string", temp)
+		}
+	}
+
+	temp, ok = ps["bodyType"]
+	if ok{
+		ms.bodyType, ok = temp.(string)
+		if !ok {
+			return fmt.Errorf("rest sink property bodyType %v is not a string", temp)
+		}
+		ms.bodyType = strings.ToLower(strings.Trim(ms.bodyType, ""))
+	}
+	if _, ok = bodyTypeMap[ms.bodyType]; !ok {
+		return fmt.Errorf("invalid property bodyType: %s, should be \"none\" or \"form\"", ms.bodyType)
+	}
+
+	temp, ok = ps["timeout"]
+	if !ok {
+		ms.timeout = 5000
+	}else{
+		to, ok := temp.(float64)
+		if !ok {
+			return fmt.Errorf("rest sink property timeout %v is not a number", temp)
+		}
+		ms.timeout = int64(to)
+	}
+
+	temp, ok = ps["sendSingle"]
+	if !ok{
+		ms.sendSingle = false
+	}else{
+		ms.sendSingle, ok = temp.(bool)
+		if !ok {
+			return fmt.Errorf("rest sink property sendSingle %v is not a bool", temp)
+		}
+	}
+
+	return nil
+}
+
+func (ms *RestSink) Open(ctx api.StreamContext) error {
+	logger := ctx.GetLogger()
+	ms.client = &http.Client{Timeout: time.Duration(ms.timeout) * time.Millisecond}
+	logger.Debugf("open rest sink with configuration: {method: %s, url: %s, bodyType: %s, timeout: %d,header: %v, sendSingle: %v", ms.method, ms.url, ms.bodyType, ms.timeout, ms.headers, ms.sendSingle)
+	return nil
+}
+
+func (ms *RestSink) Collect(ctx api.StreamContext, item interface{}) error {
+	logger := ctx.GetLogger()
+	v, ok := item.([]byte)
+	if !ok {
+		logger.Warnf("rest sink receive non []byte data: %v", item)
+	}
+	logger.Debugf("rest sink receive %s", item)
+	if !ms.sendSingle{
+		return ms.send(v, logger)
+	}else{
+		var j []map[string]interface{}
+		if err := json.Unmarshal(v, &j); err != nil {
+			return fmt.Errorf("fail to decode the input %s as json: %v", v, err)
+		}
+		logger.Debugf("receive %d records", len(j))
+		for _, r := range j{
+			ms.send(r, logger)
+		}
+	}
+	return nil
+}
+
+func (ms *RestSink) send(v interface{}, logger api.Logger) error {
+	var req *http.Request
+	var err error
+	switch ms.bodyType {
+	case "none":
+		req, err = http.NewRequest(ms.method, ms.url, nil)
+		if err != nil {
+			return fmt.Errorf("fail to create request: %v", err)
+		}
+	case "raw":
+		var content []byte
+		switch t := v.(type) {
+		case []byte:
+			content = t
+		case map[string]interface{}:
+			content, err = json.Marshal(t)
+			if err != nil{
+				return fmt.Errorf("fail to encode content: %v", err)
+			}
+		default:
+			return fmt.Errorf("invalid content: %v", v)
+		}
+		body := bytes.NewBuffer(content)
+		req, err = http.NewRequest(ms.method, ms.url, body)
+		if err != nil {
+			return fmt.Errorf("fail to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	case "form":
+		form := url.Values{}
+		switch t := v.(type) {
+		case []byte:
+			form.Set("result", string(t))
+		case map[string]interface{}:
+			for key, value := range t {
+				form.Set(key, fmt.Sprintf("%v", value))
+			}
+		default:
+			return fmt.Errorf("invalid content: %v", v)
+		}
+		body := ioutil.NopCloser(strings.NewReader(form.Encode()))
+		req, err = http.NewRequest(ms.method, ms.url, body)
+		if err != nil {
+			return fmt.Errorf("fail to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded;param=value")
+	default:
+		return fmt.Errorf("unsupported body type %s", ms.bodyType)
+	}
+
+	if len(ms.headers) > 0 {
+		for k, v := range ms.headers {
+			req.Header.Set(k, v)
+		}
+	}
+	logger.Debugf("do request: %s %s with %s", ms.method, ms.url, req.Body)
+	resp, err := ms.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("rest sink fails to send out the data")
+	} else {
+		logger.Debugf("rest sink got response %v", resp)
+	}
+	return nil
+}
+
+func (ms *RestSink) Close(ctx api.StreamContext) error {
+	logger := ctx.GetLogger()
+	logger.Infof("Closing rest sink")
+	return nil
+}


### PR DESCRIPTION
A sample rule to use for edgex core command:
"{\"sql\": \"SELECT cast(count,\\\"string\\\") as Int8 FROM ext where count > 3\",\"actions\": [{\"rest\":  {\"method\":\"put\",\"url\":\"http://127.0.0.1:48082/api/v1/device/cc622d99-f835-4e94-b5cb-b1eff8699dc4/command/51fce08a-ae19-4bce-b431-b9f363bba705\",\"sendSingle\":\"true\"}}]}"

All fields of the edgex message must be string, so a cast to string for selected field is needed. And the core command only accept a single row, so the sendSingle parameter must be true.