### PR TITLE
bug(stream): restart source should re-read the config

### DIFF
--- a/xstream/nodes/sink_node.go
+++ b/xstream/nodes/sink_node.go
@@ -57,6 +57,9 @@ func (m *SinkNode) Open(ctx api.StreamContext, result chan<- error) {
 	m.ctx = ctx
 	logger := ctx.GetLogger()
 	logger.Debugf("open sink node %s", m.name)
+	//reset the states
+	m.sinks = nil
+	m.statManagers = nil
 	go func() {
 		if c, ok := m.options["concurrency"]; ok {
 			if t, err := common.ToInt(c); err != nil || t <= 0 {

--- a/xstream/nodes/source_node.go
+++ b/xstream/nodes/source_node.go
@@ -59,6 +59,9 @@ func (m *SourceNode) Open(ctx api.StreamContext, errCh chan<- error) {
 	m.ctx = ctx
 	logger := ctx.GetLogger()
 	logger.Infof("open source node %s with option %v", m.name, m.options)
+	//Reset the states
+	m.sources = nil
+	m.statManagers = nil
 	go func() {
 		props := m.getConf(ctx)
 		if c, ok := props["concurrency"]; ok {

--- a/xstream/operators/operations.go
+++ b/xstream/operators/operations.go
@@ -87,6 +87,8 @@ func (o *UnaryOperator) Exec(ctx api.StreamContext, errCh chan<- error) {
 	if o.concurrency < 1 {
 		o.concurrency = 1
 	}
+	//reset status
+	o.statManagers = nil
 
 	for i := 0; i < o.concurrency; i++ { // workers
 		instance := i


### PR DESCRIPTION
When restart rule, the previous source/sink instances and their stats should be cleaned up so that they can be recreated with the new config. 