### PR TITLE
Fix gitbook docs build errors

### DIFF
--- a/docs/en_US/rules/overview.md
+++ b/docs/en_US/rules/overview.md
@@ -73,6 +73,7 @@ Each action can define its own properties. There are several common properties:
 If sendSingle is true, the data template will execute against a record; Otherwise, it will execute against the whole array of records. Typical data templates are:
 
 For example, we have the sink input as 
+
 ```
 []map[string]interface{}{{
     "ab" : "hello1",
@@ -99,16 +100,21 @@ In sendSingle=false mode:
 ```
 "dataTemplate": `{"content":{{json .}}}`,
 ```
+
 - Print out the first record
+
 ```
 "dataTemplate": `{"content":{{json (index . 0)}}}`,
 ```
+
 - Print out the field ab of the first record
 
 ```
 "dataTemplate": `{"content":{{index . 0 "ab"}}}`,
 ```
+
 - Print out field ab of each record in the array to html format
+
 ```
 "dataTemplate": `<div>results</div><ul>{{range .}}<li>{{.ab}}</li>{{end}}</ul>`,
 ```

--- a/docs/zh_CN/rules/overview.md
+++ b/docs/zh_CN/rules/overview.md
@@ -63,6 +63,7 @@
 If sendSingle is true, the data template will execute against a record; Otherwise, it will execute against the whole array of records. Typical data templates are:
 
 For example, we have the sink input as 
+
 ```
 []map[string]interface{}{{
     "ab" : "hello1",
@@ -77,6 +78,7 @@ In sendSingle=true mode:
 ```
 "dataTemplate": `{"content":{{json .}}}`,
 ```
+
 - Print out the the ab field
 
 ```
@@ -89,16 +91,21 @@ In sendSingle=false mode:
 ```
 "dataTemplate": `{"content":{{json .}}}`,
 ```
+
 - Print out the first record
+
 ```
 "dataTemplate": `{"content":{{json (index . 0)}}}`,
 ```
+
 - Print out the field ab of the first record
 
 ```
 "dataTemplate": `{"content":{{index . 0 "ab"}}}`,
 ```
+
 - Print out field ab of each record in the array to html format
+
 ```
 "dataTemplate": `<div>results</div><ul>{{range .}}<li>{{.ab}}</li>{{end}}</ul>`,
 ```


### PR DESCRIPTION
Gitbook uses `{{ }}` as a built-in template.You need to make sure it's in the markdown code block.