### PR TITLE
fix(sinks): fix dataTemplate type to string

### DIFF
--- a/etc/sinks/properties.json
+++ b/etc/sinks/properties.json
@@ -117,9 +117,9 @@
 		}
 	}, {
 		"name": "dataTemplate",
-		"default":true, 
+		"default":"", 
 		"optional": true,
-		"type": "bool",
+		"type": "string",
 		"control": "textarea",
 		"hint": {
 			"en_US": "The golang template format string to specify the output data format. The input of the template is the sink message which is always an array of map. If no data template is specified, the raw input will be the data.",


### PR DESCRIPTION
@jinfahua The `DataTemplate` field is a `textarea` control, which should be of `string` type, not `bool` type.