### PR TITLE
feat: Run process/container as "kuiper" user

### DIFF
--- a/deploy/docker/Dockerfile-alpine
+++ b/deploy/docker/Dockerfile-alpine
@@ -11,19 +11,34 @@ RUN make build_with_edgex
 
 FROM alpine:3.12
 
+# Set environment vars
+ENV MAINTAINER="emqx.io" \
+    KUIPER_HOME="/kuiper" \
+    KUIPER__BASIC__CONSOLELOG=true
+
+# These vars are not persisted in the final image layer
+ARG KUIPER_USER="kuiper"
+ARG KUIPER_USER_ID="1001"
+
+# (root) Add packages and "kuiper" user
+RUN apk add sed libzmq
+
 COPY ./deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 COPY --from=builder /go/kuiper/kuiper_conf_util /usr/bin/kuiper_conf_util
 COPY --from=builder /go/kuiper/_build/kuiper-* /kuiper/
 
-RUN apk add sed libzmq
+WORKDIR ${KUIPER_HOME}
 
-WORKDIR /kuiper
+# Set appropriate ownership to allow binary full access to KUIPER_HOME dir
+RUN adduser -DH -s /sbin/nologin -u ${KUIPER_USER_ID} ${KUIPER_USER} && \
+    chown -Rh ${KUIPER_USER}:${KUIPER_USER} ${KUIPER_HOME} && \
+    mkdir -p /usr/local/taos && \
+    chown -Rh ${KUIPER_USER}:${KUIPER_USER} /usr/local/taos
 
-ENV MAINTAINER="emqx.io"
-ENV KUIPER_HOME /kuiper
-ENV KUIPER__BASIC__CONSOLELOG true
+# Run the kuiper process under the kuiper user
+USER ${KUIPER_USER}
 
-VOLUME ["/kuiper/etc", "/kuiper/data", "/kuiper/plugins", "/kuiper/log"]
+VOLUME ["${KUIPER_HOME}/etc", "${KUIPER_HOME}/data", "${KUIPER_HOME}/plugins", "${KUIPER_HOME}/log"]
 EXPOSE 9081 20498
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
### Description of Issue (per commit msg)
Currently the kuiper containers run as the root user which is a potential security risk in the event the service is compromised by an attacker. This commit updates all docker files to create a non-password carrying "kuiper" user that runs the container.

### Description of Fix
Manipulated the dockerfiles to create a kuiper user, set appropriate ownership based on $KUIPER_HOME, and then switch to kuiper user (instead of root) for safe container execution. 

### How to Test
First, follow the steps below to clone the specific branch from my repository, and spin up a kuiper alpine based container. The steps below will drop you into the running container shell.
```
$ git clone --single-branch --branch run-container-as-kuiper-user https://github.com/beaufrusetta/kuiper.git kuiper-pr-test && cd kuiper-pr-test
$ make docker
$ docker run -it --rm $(docker images --filter=reference='emqx/kuiper:1.1.1*alpine' --format "{{.Repository}}:{{.Tag}}") /bin/sh
```
Run the `whoami` command at the terminal prompt to see the default user "kuiper" is executing the container and run `ls -lah $KUIPER_HOME` to see the directories owned by the new "kuiper" user.

The following dockerfiles were manipulated:
- deploy/docker/Dockerfile
- deploy/docker/Dockerfile-alpine
- deploy/docker/Dockerfile-kubernetes-tool
- deploy/docker/Dockerfile-slim