### PR TITLE
Fix links to window types in windows.md

### DIFF
--- a/docs/en_US/sqls/windows.md
+++ b/docs/en_US/sqls/windows.md
@@ -2,7 +2,7 @@
 
 In time-streaming scenarios, performing operations on the data contained in temporal windows is a common pattern. Kuiper has native support for windowing functions, enabling you to author complex stream processing jobs with minimal effort.
 
-There are five kinds of windows to use: [Tumbling window](#TUMBLING WINDOW), [Hopping window](#Hopping window), [Sliding window](#Sliding window), [Session window](#Session window) and [Count Window](#Count window). You use the window functions in the GROUP BY clause of the query syntax in your Kuiper queries. 
+There are five kinds of windows to use: [Tumbling window](#tumbling-window), [Hopping window](#hopping-window), [Sliding window](#sliding-window), [Session window](#session-window) and [Count window](#count-window). You use the window functions in the `GROUP BY` clause of the query syntax in your Kuiper queries. 
 
 All the windowing operations output results at the end of the window. The output of the window will be single event based on the aggregate function used. 
 


### PR DESCRIPTION
While reading through the docs, I noticed that the markdown was broken in this paragraph:

![image](https://user-images.githubusercontent.com/1756049/111164793-c4d62080-8574-11eb-8d94-406069da0e5e.png)

So I decided to make a quick PR to fix it.