### PR TITLE
fix: do not print out the password in config & meta fields problem

### DIFF
--- a/xstream/extensions/edgex_source_test.go
+++ b/xstream/extensions/edgex_source_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 	"github.com/emqx/kuiper/common"
+	"reflect"
 	"testing"
 )
 
@@ -310,5 +312,22 @@ func TestCastToString(t *testing.T) {
 	}
 	if v, ok := CastToString(12.3); v != "12.30" || !ok {
 		t.Errorf("Failed to cast float.")
+	}
+}
+
+func TestPrintConf(t *testing.T) {
+	expMbconf := types.MessageBusConfig{SubscribeHost: types.HostInfo{Protocol: "tcp", Host: "127.0.0.1", Port: 6625}, Type: "mbus", Optional: map[string]string{
+		"proa":     "proa",
+		"Password": "fafsadfsadf=",
+		"Prob":     "Prob",
+	}}
+	mbconf := types.MessageBusConfig{SubscribeHost: types.HostInfo{Protocol: "tcp", Host: "127.0.0.1", Port: 6625}, Type: "mbus", Optional: map[string]string{
+		"proa":     "proa",
+		"Password": "fafsadfsadf=",
+		"Prob":     "Prob",
+	}}
+	printConf(mbconf)
+	if !reflect.DeepEqual(expMbconf, mbconf) {
+		t.Errorf("conf changed after printing")
 	}
 }

--- a/xstream/operators/preprocessor.go
+++ b/xstream/operators/preprocessor.go
@@ -5,6 +5,7 @@ import (
 	"github.com/emqx/kuiper/common"
 	"github.com/emqx/kuiper/xsql"
 	"github.com/emqx/kuiper/xstream/api"
+	"strings"
 )
 
 type Preprocessor struct {
@@ -59,7 +60,9 @@ func (p *Preprocessor) Apply(ctx api.StreamContext, data interface{}, fv *xsql.F
 	if !p.allMeta && p.metaFields != nil && len(p.metaFields) > 0 {
 		newMeta := make(xsql.Metadata)
 		for _, f := range p.metaFields {
-			newMeta[f] = tuple.Metadata[f]
+			if m, ok := tuple.Metadata.Value(f); ok {
+				newMeta[strings.ToLower(f)] = m
+			}
 		}
 		tuple.Metadata = newMeta
 	}

--- a/xstream/planner/dataSourcePlan.go
+++ b/xstream/planner/dataSourcePlan.go
@@ -26,7 +26,7 @@ type DataSourcePlan struct {
 	// intermediate status
 	isWildCard bool
 	fields     map[string]interface{}
-	metaMap    map[string]bool
+	metaMap    map[string]string
 }
 
 func (p DataSourcePlan) Init() *DataSourcePlan {
@@ -76,7 +76,7 @@ func (p *DataSourcePlan) PruneColumns(fields []xsql.Expr) error {
 	p.getProps()
 	p.fields = make(map[string]interface{})
 	if !p.allMeta {
-		p.metaMap = make(map[string]bool)
+		p.metaMap = make(map[string]string)
 	}
 	if p.timestampField != "" {
 		p.fields[p.timestampField] = p.timestampField
@@ -103,7 +103,7 @@ func (p *DataSourcePlan) PruneColumns(fields []xsql.Expr) error {
 					p.allMeta = true
 					p.metaMap = nil
 				} else if !p.allMeta {
-					p.metaMap[f.Name] = true
+					p.metaMap[strings.ToLower(f.Name)] = f.Name
 				}
 			}
 		case *xsql.SortField:
@@ -164,9 +164,11 @@ func (p *DataSourcePlan) getAllFields() {
 		p.streamFields = sfs
 	}
 	p.metaFields = make([]string, 0, len(p.metaMap))
-	for k, _ := range p.metaMap {
-		p.metaFields = append(p.metaFields, k)
+	for _, v := range p.metaMap {
+		p.metaFields = append(p.metaFields, v)
 	}
+	// for consistency of results for testing
+	sort.Strings(p.metaFields)
 	p.fields = nil
 	p.metaMap = nil
 }

--- a/xstream/topotest/mock_topo.go
+++ b/xstream/topotest/mock_topo.go
@@ -49,23 +49,6 @@ func getImg() ([]byte, string) {
 	return image, b64img
 }
 
-func CleanStateData() {
-	//dbDir, err := common.GetDataLoc()
-	//if err != nil {
-	//	common.Log.Panic(err)
-	//}
-	//c := path.Join(dbDir, "checkpoints")
-	//err = os.RemoveAll(c)
-	//if err != nil {
-	//	common.Log.Errorf("%s", err)
-	//}
-	//s := path.Join(dbDir, "sink", "cache")
-	//err = os.RemoveAll(s)
-	//if err != nil {
-	//	common.Log.Errorf("%s", err)
-	//}
-}
-
 func compareMetrics(tp *xstream.TopologyNew, m map[string]interface{}) (err error) {
 	keys, values := tp.GetMetrics()
 	for k, v := range m {
@@ -1105,8 +1088,6 @@ func sendData(t *testing.T, dataLength int, metrics map[string]interface{}, data
 }
 
 func createStream(t *testing.T, tt RuleTest, j int, opt *api.RuleOption, sinkProps map[string]interface{}) ([][]*xsql.Tuple, int, *xstream.TopologyNew, *mocknodes.MockSink, <-chan error) {
-	// Rest for each test
-	CleanStateData()
 	mockclock.ResetClock(1541152486000)
 	// Create stream
 	var (

--- a/xstream/topotest/window_rule_test.go
+++ b/xstream/topotest/window_rule_test.go
@@ -284,6 +284,7 @@ func TestWindow(t *testing.T) {
 		}, {
 			Name: `TestWindowRule5`,
 			Sql:  `SELECT temp FROM sessionDemo GROUP BY SessionWindow(ss, 2, 1) `,
+			W:    10,
 			R: [][]map[string]interface{}{
 				{{
 					"temp": 25.5,


### PR DESCRIPTION
1. Fix the problem: multiple meta fields with only case differences may be retained in message. Should only have one as it is case insensitive.
2. Avoid printing out password in the log in EdgexSource.