### PR TITLE
feat(edgex):support binary type

### DIFF
--- a/common/cast.go
+++ b/common/cast.go
@@ -135,6 +135,162 @@ func ToInt(input interface{}, sn Strictness) (int, error) {
 	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to int", input)
 }
 
+func ToInt8(input interface{}, sn Strictness) (int8, error) {
+	switch s := input.(type) {
+	case int:
+		return int8(s), nil
+	case int64:
+		return int8(s), nil
+	case int32:
+		return int8(s), nil
+	case int16:
+		return int8(s), nil
+	case int8:
+		return s, nil
+	case uint:
+		return int8(s), nil
+	case uint64:
+		return int8(s), nil
+	case uint32:
+		return int8(s), nil
+	case uint16:
+		return int8(s), nil
+	case uint8:
+		return int8(s), nil
+	case float64:
+		if sn != STRICT || isIntegral64(s) {
+			return int8(s), nil
+		}
+	case float32:
+		if sn != STRICT || isIntegral32(s) {
+			return int8(s), nil
+		}
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseInt(s, 0, 0)
+			if err == nil {
+				return int8(v), nil
+			}
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to int", input)
+}
+
+func ToInt16(input interface{}, sn Strictness) (int16, error) {
+	switch s := input.(type) {
+	case int:
+		return int16(s), nil
+	case int64:
+		return int16(s), nil
+	case int32:
+		return int16(s), nil
+	case int16:
+		return int16(s), nil
+	case int8:
+		return int16(s), nil
+	case uint:
+		return int16(s), nil
+	case uint64:
+		return int16(s), nil
+	case uint32:
+		return int16(s), nil
+	case uint16:
+		return int16(s), nil
+	case uint8:
+		return int16(s), nil
+	case float64:
+		if sn != STRICT || isIntegral64(s) {
+			return int16(s), nil
+		}
+	case float32:
+		if sn != STRICT || isIntegral32(s) {
+			return int16(s), nil
+		}
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseInt(s, 0, 0)
+			if err == nil {
+				return int16(v), nil
+			}
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to int", input)
+}
+
+func ToInt32(input interface{}, sn Strictness) (int32, error) {
+	switch s := input.(type) {
+	case int:
+		return int32(s), nil
+	case int64:
+		return int32(s), nil
+	case int32:
+		return s, nil
+	case int16:
+		return int32(s), nil
+	case int8:
+		return int32(s), nil
+	case uint:
+		return int32(s), nil
+	case uint64:
+		return int32(s), nil
+	case uint32:
+		return int32(s), nil
+	case uint16:
+		return int32(s), nil
+	case uint8:
+		return int32(s), nil
+	case float64:
+		if sn != STRICT || isIntegral64(s) {
+			return int32(s), nil
+		}
+	case float32:
+		if sn != STRICT || isIntegral32(s) {
+			return int32(s), nil
+		}
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseInt(s, 0, 0)
+			if err == nil {
+				return int32(v), nil
+			}
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to int", input)
+}
+
 func ToInt64(input interface{}, sn Strictness) (int64, error) {
 	switch s := input.(type) {
 	case int:
@@ -251,6 +407,70 @@ func ToFloat64(input interface{}, sn Strictness) (float64, error) {
 	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to float64", input)
 }
 
+func ToFloat32(input interface{}, sn Strictness) (float32, error) {
+	switch s := input.(type) {
+	case float64:
+		return float32(s), nil
+	case float32:
+		return s, nil
+	case int:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case int64:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case int32:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case int16:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case int8:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case uint:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case uint64:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case uint32:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case uint16:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case uint8:
+		if sn != STRICT {
+			return float32(s), nil
+		}
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseFloat(s, 32)
+			if err == nil {
+				return float32(v), nil
+			}
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to float64", input)
+}
+
 func ToUint64(i interface{}, sn Strictness) (uint64, error) {
 	switch s := i.(type) {
 	case string:
@@ -308,6 +528,225 @@ func ToUint64(i interface{}, sn Strictness) (uint64, error) {
 		}
 		if sn != STRICT || isIntegral64(s) {
 			return uint64(s), nil
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint", i)
+}
+
+func ToUint8(i interface{}, sn Strictness) (uint8, error) {
+	switch s := i.(type) {
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseUint(s, 0, 64)
+			if err == nil {
+				return uint8(v), nil
+			}
+		}
+	case int:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint8(s), nil
+	case int64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint8(s), nil
+	case int32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint8(s), nil
+	case int16:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint8(s), nil
+	case int8:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint8(s), nil
+	case uint:
+		return uint8(s), nil
+	case uint64:
+		return uint8(s), nil
+	case uint32:
+		return uint8(s), nil
+	case uint16:
+		return uint8(s), nil
+	case uint8:
+		return s, nil
+	case float32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral32(s) {
+			return uint8(s), nil
+		}
+	case float64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral64(s) {
+			return uint8(s), nil
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint", i)
+}
+
+func ToUint16(i interface{}, sn Strictness) (uint16, error) {
+	switch s := i.(type) {
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseUint(s, 0, 64)
+			if err == nil {
+				return uint16(v), nil
+			}
+		}
+	case int:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint16(s), nil
+	case int64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint16(s), nil
+	case int32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint16(s), nil
+	case int16:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint16(s), nil
+	case int8:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint16(s), nil
+	case uint:
+		return uint16(s), nil
+	case uint64:
+		return uint16(s), nil
+	case uint32:
+		return uint16(s), nil
+	case uint16:
+		return s, nil
+	case uint8:
+		return uint16(s), nil
+	case float32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral32(s) {
+			return uint16(s), nil
+		}
+	case float64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral64(s) {
+			return uint16(s), nil
+		}
+	case bool:
+		if sn == CONVERT_ALL {
+			if s {
+				return 1, nil
+			}
+			return 0, nil
+		}
+	case nil:
+		if sn == CONVERT_ALL {
+			return 0, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint", i)
+}
+
+func ToUint32(i interface{}, sn Strictness) (uint32, error) {
+	switch s := i.(type) {
+	case string:
+		if sn == CONVERT_ALL {
+			v, err := strconv.ParseUint(s, 0, 64)
+			if err == nil {
+				return uint32(v), nil
+			}
+		}
+	case int:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint32(s), nil
+	case int64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint32(s), nil
+	case int32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint32(s), nil
+	case int16:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint32(s), nil
+	case int8:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		return uint32(s), nil
+	case uint:
+		return uint32(s), nil
+	case uint64:
+		return uint32(s), nil
+	case uint32:
+		return s, nil
+	case uint16:
+		return uint32(s), nil
+	case uint8:
+		return uint32(s), nil
+	case float32:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral32(s) {
+			return uint32(s), nil
+		}
+	case float64:
+		if s < 0 {
+			return 0, fmt.Errorf("cannot convert %[1]T(%[1]v) to uint, negative not allowed", i)
+		}
+		if sn != STRICT || isIntegral64(s) {
+			return uint32(s), nil
 		}
 	case bool:
 		if sn == CONVERT_ALL {

--- a/fvt_scripts/edgex/pub.go
+++ b/fvt_scripts/edgex/pub.go
@@ -252,6 +252,8 @@ func pubMetaSource() {
 				testEvent.Readings[1].Origin = 34 * j
 				testEvent.Readings[1].DeviceName = "Humidity sensor"
 
+				testEvent.AddBinaryReading("raw", []byte("Hello World"), "application/text")
+
 				data, err := json.Marshal(testEvent)
 				if err != nil {
 					fmt.Errorf("unexpected error MarshalEvent %v", err)

--- a/fvt_scripts/select_edgex_meta_rule.jmx
+++ b/fvt_scripts/select_edgex_meta_rule.jmx
@@ -138,7 +138,7 @@
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
                   <stringProp name="Argument.value">{&#xd;
   &quot;id&quot;: &quot;rule1&quot;,&#xd;
-  &quot;sql&quot;: &quot;SELECT temperature,humidity, meta(id) AS eid, meta(temperature-&gt;Origin) AS torigin, meta(Humidity-&gt;DeviceName) AS hdevice FROM demo WHERE meta(deviceName)=\&quot;demo2\&quot;&quot;,&#xd;
+  &quot;sql&quot;: &quot;SELECT temperature,humidity, raw, meta(id) AS eid, meta(temperature-&gt;Origin) AS torigin, meta(Humidity-&gt;DeviceName) AS hdevice, meta(raw-&gt;mediaType) as rawMedia FROM demo WHERE meta(deviceName)=\&quot;demo2\&quot;&quot;,&#xd;
   &quot;actions&quot;: [&#xd;
     {&#xd;
       &quot;mqtt&quot;: {&#xd;
@@ -465,6 +465,15 @@
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="raw Assertion" enabled="true">
+            <stringProp name="JSON_PATH">$[0].raw</stringProp>
+            <stringProp name="EXPECTED_VALUE">SGVsbG8gV29ybGQ=</stringProp>
+            <boolProp name="JSONVALIDATION">true</boolProp>
+            <boolProp name="EXPECT_NULL">false</boolProp>
+            <boolProp name="INVERT">false</boolProp>
+            <boolProp name="ISREGEX">false</boolProp>
+          </JSONPathAssertion>
+          <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="name Assertion" enabled="true">
             <stringProp name="JSON_PATH">$[0].hdevice</stringProp>
             <stringProp name="EXPECTED_VALUE">Humidity sensor</stringProp>
@@ -477,6 +486,15 @@
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="torigin Assertion" enabled="true">
             <stringProp name="JSON_PATH">$[0].torigin</stringProp>
             <stringProp name="EXPECTED_VALUE">48</stringProp>
+            <boolProp name="JSONVALIDATION">true</boolProp>
+            <boolProp name="EXPECT_NULL">false</boolProp>
+            <boolProp name="INVERT">false</boolProp>
+            <boolProp name="ISREGEX">false</boolProp>
+          </JSONPathAssertion>
+          <hashTree/>
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="rawMedia Assertion" enabled="true">
+            <stringProp name="JSON_PATH">$[0].rawMedia</stringProp>
+            <stringProp name="EXPECTED_VALUE">application/text</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>

--- a/xstream/extensions/edgex_source.go
+++ b/xstream/extensions/edgex_source.go
@@ -149,6 +149,9 @@ func (es *EdgexSource) Open(ctx api.StreamContext, consumer chan<- api.SourceTup
 								r_meta["deviceName"] = r.DeviceName
 								r_meta["profileName"] = r.ProfileName
 								r_meta["valueType"] = r.ValueType
+								if r.MediaType != "" {
+									r_meta["mediaType"] = r.MediaType
+								}
 								meta[r.ResourceName] = r_meta
 							} else {
 								log.Warnf("The name of readings should not be empty!")
@@ -246,8 +249,15 @@ func (es *EdgexSource) getValue(r dtos.BaseReading, logger api.Logger) (interfac
 		return convertFloatArray(v, 32)
 	case v2.ValueTypeFloat64Array:
 		return convertFloatArray(v, 64)
+	case v2.ValueTypeStringArray:
+		var val []string
+		if e := json.Unmarshal([]byte(v), &val); e == nil {
+			return val, nil
+		} else {
+			return nil, e
+		}
 	case v2.ValueTypeBinary:
-		return nil, fmt.Errorf("Unsupport for binary type, the value will be ignored.")
+		return r.BinaryValue, nil
 	default:
 		logger.Warnf("Not supported type %s, and processed as string value", t)
 		return v, nil

--- a/xstream/extensions/edgex_source_test.go
+++ b/xstream/extensions/edgex_source_test.go
@@ -329,3 +329,13 @@ func TestPrintConf(t *testing.T) {
 		t.Errorf("conf changed after printing")
 	}
 }
+
+func TestGetValue_Binary(t *testing.T) {
+	ev := []byte("Hello World")
+	r1 := dtos.BaseReading{ResourceName: "bin", ValueType: v2.ValueTypeBinary, BinaryReading: dtos.BinaryReading{MediaType: "application/text", BinaryValue: ev}}
+	if v, e := es.getValue(r1, common.Log); e != nil {
+		t.Errorf("%s", e)
+	} else if !reflect.DeepEqual(ev, v) {
+		t.Errorf("result mismatch, expect %v, but got %v", ev, v)
+	}
+}

--- a/xstream/sinks/edgex_sink_test.go
+++ b/xstream/sinks/edgex_sink_test.go
@@ -49,7 +49,7 @@ func TestProduceEvents(t1 *testing.T) {
 			input: `[
 						{"meta":{
 							"correlationid":"","deviceName":"demo","id":"","origin":3,
-							"humidity":{"deviceName":"test device name1","id":"12","origin":14,"valueType":"int64"},
+							"humidity":{"deviceName":"test device name1","id":"12","origin":14,"valueType":"Int64"},
 							"temperature":{"deviceName":"test device name2","id":"22","origin":24}
 							}
 						},
@@ -194,6 +194,42 @@ func TestProduceEvents(t1 *testing.T) {
 				Origin:      0,
 				Readings:    nil,
 			},
+		},
+		{
+			input: `[
+						{"meta1": "newmeta"},
+						{"sa":"SGVsbG8gV29ybGQ="},
+						{"meta":{
+							"correlationid":"","profileName":"demoProfile","deviceName":"demo","sourceName":"demoSource","id":"abc","origin":3,"tags":{"auth":"admin"},
+							"sa":{"deviceName":"test device name1","id":"12","origin":14, "valueType":"Binary","mediaType":"application/css"}
+						}}
+					]`,
+			expected: &dtos.Event{
+				DeviceName:  "demo",
+				ProfileName: "demoProfile",
+				SourceName:  "demoSource",
+				Origin:      3,
+				Tags:        map[string]string{"auth": "admin"},
+				Readings: []dtos.BaseReading{
+					{
+						DeviceName:    "demo",
+						ProfileName:   "demoProfile",
+						ResourceName:  "meta1",
+						SimpleReading: dtos.SimpleReading{Value: "newmeta"},
+						ValueType:     v2.ValueTypeString,
+					},
+					{
+						ResourceName:  "sa",
+						BinaryReading: dtos.BinaryReading{BinaryValue: []byte("Hello World"), MediaType: "application/css"},
+						ProfileName:   "demoProfile",
+						DeviceName:    "test device name1",
+						Id:            "12",
+						Origin:        14,
+						ValueType:     v2.ValueTypeBinary,
+					},
+				},
+			},
+			error: "",
 		},
 	}
 


### PR DESCRIPTION
1. Support binary reading
2. In EdgexSink, add type casting when valueType is specified. Need this because edgex typing is very strict
3. Fix a problem in EdgexSource for missing converting string array
4. Fix a problem in EdgexSink for missing reading valueType meta
5. Add test cases for binary type
6. Add FVT test case for binary together in the meta test